### PR TITLE
feat: use caps instead of boolean

### DIFF
--- a/src/agents/MonarchAgent.sol
+++ b/src/agents/MonarchAgent.sol
@@ -105,8 +105,7 @@ contract MonarchAgentV1 is IMonarchAgent {
         for (uint256 i; i < toMarkets.length; ++i) {
             require(toMarkets[i].market.loanToken == token, ErrorsLib.INVALID_TOKEN);
 
-            (uint256 assetsSupplied,) =
-                _supplyAndCheckCap(toMarkets[i].market, toMarkets[i].assets, toMarkets[i].shares, onBehalf);
+            uint256 assetsSupplied = _supplyAndCheckCap(toMarkets[i].market, toMarkets[i].assets, toMarkets[i].shares, onBehalf);
             tokenDelta -= int256(assetsSupplied);
         }
 
@@ -124,12 +123,14 @@ contract MonarchAgentV1 is IMonarchAgent {
     }
 
     /// @dev supply asset on behalf of user and check if the cap is exceeded
+    /// @dev returns total assets supplied
     function _supplyAndCheckCap(MarketParams memory market, uint256 assets, uint256 shares, address onBehalf)
         internal
-        returns (uint256 assetsSupplied, uint256 sharesSupplied)
+        returns (uint256 assetsSupplied)
     {
         Id marketId = market.id();
 
+        uint256 sharesSupplied;
         (assetsSupplied, sharesSupplied) = morphoBlue.supply(market, assets, shares, onBehalf, bytes(""));
 
         // the final supplied asset cannot exceed the cap if set

--- a/src/agents/MonarchAgent.sol
+++ b/src/agents/MonarchAgent.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 
 import {IMonarchAgent, RebalanceMarketParams} from "../interfaces/IMonarchAgent.sol";
-import {IMorpho, Id, MarketParams} from "morpho-blue/src/interfaces/IMorpho.sol";
+import {IMorpho, Id, MarketParams, Position} from "morpho-blue/src/interfaces/IMorpho.sol";
 import {MarketParamsLib} from "morpho-blue/src/libraries/MarketParamsLib.sol";
 import {SafeTransferLib, ERC20} from "solmate/src/utils/SafeTransferLib.sol";
 import {ErrorsLib} from "../libraries/ErrorsLib.sol";
@@ -24,7 +24,7 @@ contract MonarchAgentV1 is IMonarchAgent {
     mapping(address user => address rebalancer) public rebalancers;
 
     /// @notice rebalancers can only rebalance to enabled market
-    mapping(address user => mapping(bytes32 marketId => bool)) marketEnabled;
+    mapping(address user => mapping(bytes32 marketId => uint256 cap)) marketCap;
 
     /* CONSTRUCTOR */
 
@@ -65,13 +65,14 @@ contract MonarchAgentV1 is IMonarchAgent {
     /**
      * @notice enable rebalancers to rebalance to specific market ids
      * @param marketIds array of market id
-     * @param enabled bool for enable
+     * @param caps array of market cap
      */
-    function batchEnableMarkets(bytes32[] calldata marketIds, bool enabled) external {
+    function batchConfigMarkets(bytes32[] calldata marketIds, uint256[] calldata caps) external {
+        require(marketIds.length == caps.length, ErrorsLib.INVALID_LENGTH);
         for (uint256 i; i < marketIds.length; i++) {
-            marketEnabled[msg.sender][marketIds[i]] = enabled;
+            marketCap[msg.sender][marketIds[i]] = caps[i];
 
-            emit MarketEnabled(msg.sender, marketIds[i], enabled);
+            emit MarketConfigured(msg.sender, marketIds[i], caps[i]);
         }
     }
 
@@ -104,11 +105,8 @@ contract MonarchAgentV1 is IMonarchAgent {
         for (uint256 i; i < toMarkets.length; ++i) {
             require(toMarkets[i].market.loanToken == token, ErrorsLib.INVALID_TOKEN);
 
-            bytes32 marketId = Id.unwrap(toMarkets[i].market.id());
-            require(marketEnabled[onBehalf][marketId], ErrorsLib.NOT_ENABLED);
-
             (uint256 assetsSupplied,) =
-                morphoBlue.supply(toMarkets[i].market, toMarkets[i].assets, toMarkets[i].shares, onBehalf, bytes(""));
+                _supplyAndCheckCap(toMarkets[i].market, toMarkets[i].assets, toMarkets[i].shares, onBehalf);
             tokenDelta -= int256(assetsSupplied);
         }
 
@@ -123,5 +121,21 @@ contract MonarchAgentV1 is IMonarchAgent {
         if (ERC20(asset).allowance(address(this), spender) == 0) {
             ERC20(asset).safeApprove(spender, type(uint256).max);
         }
+    }
+
+    /// @dev supply asset on behalf of user and check if the cap is exceeded
+    function _supplyAndCheckCap(MarketParams memory market, uint256 assets, uint256 shares, address onBehalf)
+        internal
+        returns (uint256 assetsSupplied, uint256 sharesSupplied)
+    {
+        Id marketId = market.id();
+
+        (assetsSupplied, sharesSupplied) = morphoBlue.supply(market, assets, shares, onBehalf, bytes(""));
+
+        // the final supplied asset cannot exceed the cap if set
+        Position memory position = morphoBlue.position(marketId, onBehalf);
+        uint256 totalSupplyAssets = position.supplyShares * assetsSupplied / sharesSupplied;
+
+        require(marketCap[onBehalf][Id.unwrap(marketId)] >= totalSupplyAssets, ErrorsLib.CAP_EXCEEDED);
     }
 }

--- a/src/agents/MonarchAgent.sol
+++ b/src/agents/MonarchAgent.sol
@@ -24,7 +24,7 @@ contract MonarchAgentV1 is IMonarchAgent {
     mapping(address user => address rebalancer) public rebalancers;
 
     /// @notice rebalancers can only rebalance to enabled market
-    mapping(address user => mapping(bytes32 marketId => uint256 cap)) marketCap;
+    mapping(address user => mapping(bytes32 marketId => uint256 cap)) public marketCap;
 
     /* CONSTRUCTOR */
 

--- a/src/interfaces/IMonarchAgent.sol
+++ b/src/interfaces/IMonarchAgent.sol
@@ -14,7 +14,7 @@ interface IMonarchAgent {
     event RebalancerSet(address indexed user, address indexed rebalancer);
 
     /// @notice Emitted when a market is enabled for a user
-    event MarketEnabled(address indexed user, bytes32 indexed marketId, bool enabled);
+    event MarketConfigured(address indexed user, bytes32 indexed marketId, uint256 cap);
 
     /// @notice Emitted when a rebalancing operation is performed
     event Rebalance(

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -23,4 +23,10 @@ library ErrorsLib {
 
     /// @notice Thrown when marketID not enabled by user
     string internal constant NOT_ENABLED = "not-enabled";
+
+    /// @notice Thrown when the length of the array is invalid.
+    string internal constant INVALID_LENGTH = "invalid length";
+
+    /// @notice Thrown when the cap is exceeded.
+    string internal constant CAP_EXCEEDED = "cap exceeded";
 }

--- a/test/shared/AgentTestBase.t.sol
+++ b/test/shared/AgentTestBase.t.sol
@@ -24,8 +24,10 @@ contract AgentTestBase is BaseTest {
         vm.prank(user);
         bytes32 marketId = Id.unwrap(market.id());
         bytes32[] memory markets = new bytes32[](1);
+        uint256[] memory caps = new uint256[](1);
         markets[0] = marketId;
-        agent.batchEnableMarkets(markets, true);
+        caps[0] = type(uint256).max;
+        agent.batchConfigMarkets(markets, caps);
         vm.stopPrank();
     }
 

--- a/test/shared/AgentTestBase.t.sol
+++ b/test/shared/AgentTestBase.t.sol
@@ -21,14 +21,7 @@ contract AgentTestBase is BaseTest {
     }
 
     function _enableMarket(address user, MarketParams memory market) internal {
-        vm.prank(user);
-        bytes32 marketId = Id.unwrap(market.id());
-        bytes32[] memory markets = new bytes32[](1);
-        uint256[] memory caps = new uint256[](1);
-        markets[0] = marketId;
-        caps[0] = type(uint256).max;
-        agent.batchConfigMarkets(markets, caps);
-        vm.stopPrank();
+        _setMarketCap(user, market, type(uint256).max);
     }
 
     function _createMarket(uint256 lltv) internal returns (MarketParams memory) {
@@ -39,6 +32,17 @@ contract AgentTestBase is BaseTest {
     function _createAndEnableMarket(address user, uint256 lltv) internal returns (MarketParams memory market) {
         market = _createMarket(lltv);
         _enableMarket(user, market);
+    }
+
+    function _setMarketCap(address user, MarketParams memory market, uint256 cap) internal {
+        vm.startPrank(user);
+        bytes32 marketId = Id.unwrap(market.id());
+        bytes32[] memory markets = new bytes32[](1);
+        uint256[] memory caps = new uint256[](1);
+        markets[0] = marketId;
+        caps[0] = cap;
+        agent.batchConfigMarkets(markets, caps);
+        vm.stopPrank();
     }
 
     function _supplyMorpho(MarketParams memory market, uint256 assets, uint256 shares, address user) internal {

--- a/test/unit-tests/Rebalance.t.sol
+++ b/test/unit-tests/Rebalance.t.sol
@@ -127,7 +127,7 @@ contract AgentRebalanceTest is AgentTestBase {
 
         vm.prank(rebalancer);
 
-        vm.expectRevert(bytes(ErrorsLib.NOT_ENABLED));
+        vm.expectRevert(bytes(ErrorsLib.CAP_EXCEEDED));
         agent.rebalance(user, address(loanToken), from_markets, to_markets);
     }
 

--- a/test/unit-tests/SetCap.t.sol
+++ b/test/unit-tests/SetCap.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import {AgentTestBase} from "test/shared/AgentTestBase.t.sol";
+import {ErrorsLib} from "../../src/libraries/ErrorsLib.sol";
+
+contract AgentSetCapTest is AgentTestBase {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function test_SetCap() public {
+        address user = address(0x1);
+
+        vm.startPrank(user);
+        bytes32 marketId = keccak256(abi.encode("mock market"));
+
+        bytes32[] memory markets = new bytes32[](1);
+        uint256[] memory caps = new uint256[](1);
+        markets[0] = marketId;
+        caps[0] = 1000;
+        agent.batchConfigMarkets(markets, caps);
+        vm.stopPrank();
+
+        assertEq(agent.marketCap(user, marketId), caps[0]);
+    }
+
+    function test_SetCap_Batch() public {
+        address user = address(0x1);
+
+        vm.startPrank(user);
+        bytes32[] memory markets = new bytes32[](2);
+        uint256[] memory caps = new uint256[](2);
+        markets[0] = keccak256(abi.encode("mock market 1"));
+        caps[0] = 1000;
+        markets[1] = keccak256(abi.encode("mock market 2"));
+        caps[1] = 2000;
+        agent.batchConfigMarkets(markets, caps);
+        vm.stopPrank();
+
+        assertEq(agent.marketCap(user, markets[0]), caps[0]);
+        assertEq(agent.marketCap(user, markets[1]), caps[1]);
+    }
+
+    function test_RevertIf_LengthMismatch() public {
+        address user = address(0x1);
+
+        vm.startPrank(user);
+        vm.expectRevert(bytes(ErrorsLib.INVALID_LENGTH));
+        agent.batchConfigMarkets(new bytes32[](0), new uint256[](1));
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
## Summary
Add caps for each market, regulating post-supply total exposure to a market

## Details
We no longer need the "enabled" flag, just set the cap to 0!

## Todo
- [x] Unit tests for function
- [x] Unit test -- rebalance exceed market

## Checklist
Ensure you completed all of the steps below before submitting your pull request:

- [x] Add natspec for all functions / parameters
- [x] Ran `forge fmt`
- [x] Ran `forge test`